### PR TITLE
增加Java通用工具库Hutool

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ Awesome 系列虽然挺全，但基本只对收录的资源做了极为简要的
 * [javatuples](http://hao.jobbole.com/javatuples/)：正如名字表示的那样，提供tuple支持。尽管目前tuple的概念还有留有争议。[官网](http://www.javatuples.org/)
 * [JCommander](http://hao.jobbole.com/jcommander/)：命令行参数解析器。[官网](http://jcommander.org/)
 * [Protégé](http://hao.jobbole.com/protege/)：提供存在论（ontology）编辑器以及构建知识系统的框架。[官网](http://protege.stanford.edu/)
+* [Hutool](http://hao.jobbole.com/guava/)：一个Java工具集，提供对配置、数据库操作、文件、流、加密解密、正则、线程、日期、HTTP等工具封装。[官网](https://hutool.cn)
 
 <h3 id="web-crawling">网络爬虫</h3>
 

--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ Awesome 系列虽然挺全，但基本只对收录的资源做了极为简要的
 * [javatuples](http://hao.jobbole.com/javatuples/)：正如名字表示的那样，提供tuple支持。尽管目前tuple的概念还有留有争议。[官网](http://www.javatuples.org/)
 * [JCommander](http://hao.jobbole.com/jcommander/)：命令行参数解析器。[官网](http://jcommander.org/)
 * [Protégé](http://hao.jobbole.com/protege/)：提供存在论（ontology）编辑器以及构建知识系统的框架。[官网](http://protege.stanford.edu/)
-* [Hutool](http://hao.jobbole.com/guava/)：一个Java工具集，提供对配置、数据库操作、文件、流、加密解密、正则、线程、日期、HTTP等工具封装。[官网](https://hutool.cn)
+* [Hutool](https://github.com/looly/hutool)：一个Java工具集，缓存、HTTP、加密解密、DFA、JSON、分组配置文件、数据库操作、图片验证码、Excel读写、定时任务、模板引擎、邮件、Servlet、二维码、Emoji、分词等一系列工具类。[官网](https://hutool.cn)
 
 <h3 id="web-crawling">网络爬虫</h3>
 


### PR DESCRIPTION
Hutool是一个通用工具库。

Gtihub地址是：https://github.com/looly/hutool ，目前获得5800+的star。
主页地址：https://hutool.cn
文档地址：https://hutool.cn/docs/#/

此工具提供了缓存、HTTP、加密解密、DFA、JSON、分组配置文件、基于ActiveRecord思想的数据库操作工具、图片验证码、Excel读写封装、定时任务、模板引擎、邮件、Servlet、二维码、Emoji、FTP、分词等一系列工具类。

此工具库提供了完整的中文注释，简化代码编写。